### PR TITLE
Remove unused imports in RobotContainer.java

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -4,9 +4,7 @@
 
 package frc.robot;
 
-import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
-import frc.robot.Constants.OperatorConstants;
-import frc.robot.subsystems.ExampleSubsystem;
+
 import frc.robot.subsystems.Drivetrain;
 
 


### PR DESCRIPTION
This PR performs a minor cleanup in RobotContainer.java by removing unused imports that were generating warnings in VS Code. These imports were not used anywhere in the class and have been removed to improve maintainability and adhere to Java best practices. No logic or robot behavior is affected by this change.